### PR TITLE
Don't auto-complete 'classifiers' from classifiers.txt any more

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,14 @@
 Release notes
 =============
 
+
+2.9.0 (2021-03-15)
+------------------
+
+* Don't auto-complete ``classifiers`` from ``classifiers.txt`` any more,
+  the added value of that is negligible (and potentially confusing)
+
+
 2.8.3 (2021-01-07)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,6 @@ note that a lot of info is typically extracted from your project, if you follow 
               author: (auto-adjust     ) Your Name
                   \_: (myproject.py:7  ) Your Name<your@email.com>
         author_email: (auto-adjust     ) your@email.com
-         classifiers: (classifiers.txt ) 6 items: ["Development Status :: ...
          description: (README.rst:1    ) First line of your README
         entry_points: (entry_points.ini) [console_scripts] ...
     install_requires: (requirements.txt) ["click", ...
@@ -92,8 +91,6 @@ How it works?
 * ``packages`` and ``package_dir`` is auto-filled accordingly if you have a ``<name>/__init__.py`` or ``src/<name>/__init__.py`` file
 
 * ``py_modules`` is auto-filled if you have a ``<name>.py`` file
-
-* ``classifiers`` is auto-filled from file ``classifiers.txt`` (one classification per line, ignoring empty lines and python style comments)
 
 * ``entry_points`` is auto-filled from file ``entry_points.ini`` (bonus: tools like PyCharm have a nice syntax highlighter for those)
 

--- a/examples/direct/classifiers.txt
+++ b/examples/direct/classifiers.txt
@@ -1,2 +1,0 @@
-Framework :: Pytest
-Programming Language :: Python

--- a/examples/direct/expected.txt
+++ b/examples/direct/expected.txt
@@ -3,7 +3,6 @@
                            \_: (direct/__init__.py:5 ) Someone someone@example.com
                  author_email: (auto-adjust          ) someone@example.com
                  bugtrack_url: (auto-fill            ) https://github.com/codrsquad/simple/issues
-                  classifiers: (classifiers.txt      ) ["Framework :: Pytest", "Programming Language :: Python"]
                   description: (direct/__init__.py:2 ) A package implemented by one direct (not under src/) module folder
                  download_url: (auto-fill            ) https://github.com/codrsquad/simple/archive/1.0.0.tar.gz
                            \_: (direct/__init__.py:10) https://github.com/codrsquad/simple/archive/{version}.tar.gz
@@ -37,7 +36,6 @@ setup(
     author="Someone",                                                # from direct/__init__.py:5
     author_email="someone@example.com",
     bugtrack_url="https://github.com/codrsquad/simple/issues",
-    classifiers=["Framework :: Pytest", "Programming Language :: Python"], # from classifiers.txt
     description="A package implemented by one direct (not under src/) module folder", # from direct/__init__.py:2
     download_url="https://github.com/codrsquad/simple/archive/%s.tar.gz" % __version__, # from direct/__init__.py:10
     entry_points="""[console_scripts]

--- a/examples/hierarchical/classifiers.txt
+++ b/examples/hierarchical/classifiers.txt
@@ -1,2 +1,0 @@
-Framework :: Pytest
-Programming Language :: Python

--- a/examples/hierarchical/expected.txt
+++ b/examples/hierarchical/expected.txt
@@ -3,7 +3,6 @@
                            \_: (src/hierarchical/__init__.py:5 ) Someone someone@example.com
                  author_email: (auto-adjust                    ) someone@example.com
                  bugtrack_url: (auto-fill                      ) https://github.com/codrsquad/hierarchical/issues
-                  classifiers: (classifiers.txt                ) ["Framework :: Pytest", "Programming Language :: Python"]
                   description: (README.rst:1                   ) A hierarchical package (code under src/)
                            \_: (src/hierarchical/__init__.py:2 ) A hierarchical package (code under src/, tests under tests/)
                  download_url: (auto-fill                      ) https://github.com/codrsquad/hierarchical/archive/1.0.0.tar.gz
@@ -40,7 +39,6 @@ setup(
     author="Someone",                                                 # from src/hierarchical/__init__.py:5
     author_email="someone@example.com",
     bugtrack_url="https://github.com/codrsquad/hierarchical/issues",
-    classifiers=["Framework :: Pytest", "Programming Language :: Python"], # from classifiers.txt
     description="A hierarchical package (code under src/)",           # from README.rst:1
     download_url="https://github.com/codrsquad/hierarchical/archive/%s.tar.gz" % __version__, # from src/hierarchical/__init__.py:10
     entry_points="""[console_scripts]

--- a/examples/single/expected.txt
+++ b/examples/single/expected.txt
@@ -2,7 +2,6 @@
                        author: (auto-adjust ) Someone
                            \_: (single.py:5 ) Someone someone@example.com
                  author_email: (auto-adjust ) someone@example.com
-                  classifiers: (missing     ) - Consider specifying 'classifiers'
                   description: (README.rst:1) A package implemented by a single .py file
                            \_: (setup.py:3  ) Unicode chars in setup.py 😀 😎
                  download_url: (missing     ) - Consider specifying 'download_url'

--- a/examples/via-cfg/expected.txt
+++ b/examples/via-cfg/expected.txt
@@ -2,7 +2,6 @@
                        author: (auto-adjust) Someone
                            \_: (explicit   ) Someone someone@example.org
                  author_email: (auto-adjust) someone@example.org
-                  classifiers: (missing    ) - Consider specifying 'classifiers'
                   description: (README.md:1) All settings come from `setup.cfg`
                  download_url: (missing    ) - Consider specifying 'download_url'
                  entry_points: (explicit   ) {console_scripts: ["pytest=pytest:main"]}

--- a/setupmeta/commands.py
+++ b/setupmeta/commands.py
@@ -292,7 +292,6 @@ class ExplainCommand(setuptools.Command):
         self.check_recommend("long_description", "add a README file")
         if self.recommend:
             self.check_recommend("author")
-            self.check_recommend("classifiers")
             self.check_recommend("download_url")
             self.check_recommend("license")
             self.check_recommend("url")

--- a/setupmeta/content.py
+++ b/setupmeta/content.py
@@ -56,37 +56,6 @@ def load_readme(relative_path, limit=0):
         return "".join(content).strip()
 
 
-def extract_list(content, comment="#"):
-    """List of non-comment, non-empty strings from 'content'
-
-    :param str|None content: Text content
-    :param str|None comment: Optional comment marker
-    :return list(str)|None: Contents, if any
-    """
-    if content is None:
-        return None
-    result = []
-    for line in content.strip().split("\n"):
-        if comment and comment in line:
-            i = line.index(comment)
-            line = line[:i]
-        line = line.strip()
-        if line:
-            result.append(line)
-    return result
-
-
-def load_list(relative_path, comment="#", limit=0):
-    """List of non-comment, non-empty strings from file
-
-    :param str relative_path: Relative path to file
-    :param str|None comment: Optional comment marker
-    :param int limit: Max number of lines to load
-    :return list(str)|None: Contents, if any
-    """
-    return extract_list(load_contents(relative_path, limit=limit), comment=comment)
-
-
 def resolved_paths(relative_paths):
     """
     :param list(str) relative_paths: Ex: "README.rst", "README*"

--- a/setupmeta/license.py
+++ b/setupmeta/license.py
@@ -70,7 +70,7 @@ KNOWN_LICENSES = [
 def determined_license(contents):
     """
     :param str|None contents: Contents to determine license from
-    :return tuple(str, str): Short name and classifier name
+    :return str: Short license name
     """
     for license in KNOWN_LICENSES:
         short = license.match(contents)

--- a/setupmeta/model.py
+++ b/setupmeta/model.py
@@ -12,7 +12,7 @@ import setuptools
 
 from setupmeta import current_folder, get_words, listify, MetaDefs, PKGID, project_path, readlines, relative_path
 from setupmeta import Requirements, requirements_from_file, short, trace, warn
-from setupmeta.content import find_contents, load_contents, load_list, load_readme, resolved_paths
+from setupmeta.content import find_contents, load_contents, load_readme, resolved_paths
 from setupmeta.license import determined_license
 from setupmeta.versioning import project_scm, Versioning
 
@@ -25,7 +25,6 @@ except NameError:
 
 # Used to mark which key/values were provided explicitly in setup.py
 EXPLICIT = "explicit"
-CLASSIFIERS = "classifiers.txt"
 READMES = ["README.rst", "README.md", "README*"]
 
 # Accept reasonable variations of name + some separator + email
@@ -550,12 +549,10 @@ class SetupMeta(Settings):
         if self.requirements.dependency_links:
             self.auto_fill("dependency_links", self.requirements.dependency_links, self.requirements.links_source)
 
-        self.auto_fill_classifiers()
         self.auto_fill_entry_points()
         self.auto_fill_license()
         self.auto_fill_long_description()
         self.auto_fill_include_package_data()
-        self.sort_classifiers()
 
         return self
 
@@ -682,17 +679,6 @@ class SetupMeta(Settings):
     @property
     def version(self):
         return self.value("version")
-
-    def auto_fill_classifiers(self):
-        """ Add classifiers from classifiers.txt, if present """
-        # https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        self.add_definition("classifiers", load_list(CLASSIFIERS), CLASSIFIERS)
-
-    def sort_classifiers(self):
-        """ Sort classifiers alphabetically """
-        classifiers = self.definitions.get("classifiers")
-        if classifiers and isinstance(classifiers.value, list):
-            classifiers.value = sorted(classifiers.value)
 
     def auto_fill_include_package_data(self):
         """Auto-fill 'include_package_data' if a MANIFEST.in file exists in project"""

--- a/tests/scenarios/So complex/classifiers.txt
+++ b/tests/scenarios/So complex/classifiers.txt
@@ -1,7 +1,0 @@
-#
-Programming Language :: Python      # Some comment
-
-Intended Audience :: Developers
-
-Operating System :: POSIX
-Operating System :: Unix

--- a/tests/scenarios/So complex/expected.txt
+++ b/tests/scenarios/So complex/expected.txt
@@ -4,7 +4,6 @@ WARNING: In setup.py:6 version should be '1.2.3', not '1.0a1'
               \_: (setup.py:2                          ) Someone someone@example.com
     author_email: (auto-adjust                         ) someone@example.com
      classifiers: (explicit                            ) ["Programming Language :: Python"]
-              \_: (classifiers.txt                     ) 4 items: ["Programming Language :: Python", "Intended Audience :: Developers", "Operating System :: POSIX", "Operating S...
          contact: (src/My_cplx_nm_here/__init__.py:14  ) Someone
    contact_email: (src/My_cplx_nm_here/__init__.py:15  ) me@example.com
      description: (README:1                            ) My cplx-nm_here - Sample complex project
@@ -188,7 +187,6 @@ Running: <target>/.hooks/bump "My cplx-nm_here" master 2.0.0
               \_: (setup.py:2                          ) Someone someone@example.com
     author_email: (auto-adjust                         ) someone@example.com
      classifiers: (explicit                            ) ["Programming Language :: Python"]
-              \_: (classifiers.txt                     ) 4 items: ["Programming Language :: Python", "Intended Audience :: Developers", "Operating System :: POSIX", "Operating S...
          contact: (src/My_cplx_nm_here/__init__.py:14  ) Someone
    contact_email: (src/My_cplx_nm_here/__init__.py:15  ) me@example.com
      description: (README:1                            ) My cplx-nm_here - Sample complex project

--- a/tests/scenarios/bogus/expected.txt
+++ b/tests/scenarios/bogus/expected.txt
@@ -1,7 +1,6 @@
 :: explain -c180 -r
 WARNING: patch version component should be .0 for versioning strategy...
                        author: (missing    ) - Consider specifying 'author'
-                  classifiers: (missing    ) - Consider specifying 'classifiers'
                   description: (README.md:1) bogus versioning spec
                  download_url: (missing    ) - Consider specifying 'download_url'
                       license: (missing    ) - Consider specifying 'license'

--- a/tests/scenarios/complex-reqs/expected.txt
+++ b/tests/scenarios/complex-reqs/expected.txt
@@ -1,6 +1,5 @@
 :: explain -c180 -r
                        author: (missing             ) - Consider specifying 'author'
-                  classifiers: (missing             ) - Consider specifying 'classifiers'
              dependency_links: (requirements.txt    ) ["git+https://example.com/a.git#egg=flake8", "git+https://example.com/c.git#egg=flake8"]
                   description: (README.md:1         ) Project with a complex requirements.txt file
                  download_url: (missing             ) - Consider specifying 'download_url'

--- a/tests/scenarios/pinned/expected.txt
+++ b/tests/scenarios/pinned/expected.txt
@@ -2,7 +2,6 @@
           author: (auto-adjust) Someone
               \_: (pinned.py:5) Someone someone@example.com
     author_email: (auto-adjust) someone@example.com
-     classifiers: (missing    ) - Consider specifying 'classifiers'
      description: (setup.py:3 ) This is a package that has setupmeta pinned to an explicit version range.
     download_url: (missing    ) - Consider specifying 'download_url'
          license: (pinned.py:4) MIT

--- a/tests/scenarios/readmes/expected.txt
+++ b/tests/scenarios/readmes/expected.txt
@@ -1,6 +1,5 @@
 :: explain -c180 -r
                        author: (missing   ) - Consider specifying 'author'
-                  classifiers: (missing   ) - Consider specifying 'classifiers'
                   description: (README:1  ) Several readme files
                  download_url: (setup.py:2) http://example.com/readmes
                          foo*: (setup.py:3) bar

--- a/tests/scenarios/simple-src/expected.txt
+++ b/tests/scenarios/simple-src/expected.txt
@@ -1,6 +1,5 @@
 :: explain -c180 -r
           author: (missing  ) - Consider specifying 'author'
-     classifiers: (missing  ) - Consider specifying 'classifiers'
      description: (missing  ) - Consider specifying 'description', add a README or a docstring to your module
     download_url: (missing  ) - Consider specifying 'download_url'
          license: (missing  ) - Consider specifying 'license'

--- a/tests/scenarios/via_req_files/expected.txt
+++ b/tests/scenarios/via_req_files/expected.txt
@@ -1,6 +1,5 @@
 :: explain -c180 -r
                        author: (missing         ) - Consider specifying 'author'
-                  classifiers: (missing         ) - Consider specifying 'classifiers'
                   description: (README.md:1     ) via_req_files spec
                  download_url: (missing         ) - Consider specifying 'download_url'
                extras_require: (preprocessed    ) {extra: ["d", "e", "f"], feature: ["a", "b", "c"], missing: []}


### PR DESCRIPTION
The added value of it was negligible, and it can be confusing if one has a `classifiers.txt` at top of repo unrelated to setupmeta