### PR TITLE
Pep440 compliance

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,7 @@ Release notes
 
 * This is relatively large change, it could have justified a major version bump,
   but the previous addition was relatively minor. So going to hold off on bumping major yet.
-  If you find an issue, please pin to prev version, or ``<2.9`` and report_
+  If you find an issue, please pin to the previous version, or ``<2.9`` and report_ it.
 
 * Yield PEP-440_ compliant versions:
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,8 +7,9 @@ Release notes
 ------------------
 
 * This is relatively large change, it could have justified a major version bump,
-  but the previous addition was relatively minor. So going to hold off on bumping major yet.
-  If you find an issue, please pin to the previous version, or ``<2.9`` and report_ it.
+  but the previous release 2.9.0 is rather an un-impactful one.
+  So going to hold off on bumping major here.
+  If you find an issue, please pin to the previous version (or even ``< 2.9``) and report_ it.
 
 * Yield PEP-440_ compliant versions:
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,23 +3,27 @@ Release notes
 =============
 
 
-2.9.1 (2021-03-22)
+3.0.0 (2021-03-22)
 ------------------
 
-* This is relatively large change, it could have justified a major version bump,
-  but the previous release 2.9.0 is rather an un-impactful one.
-  So going to hold off on bumping major here.
-  If you find an issue, please pin to the previous version (or even ``< 2.9``) and report_ it.
+* Yield PEP-440_ compliant versions
 
-* Yield PEP-440_ compliant versions:
+* Versions yielded by ``setupmeta`` 3.0 will differ from pre-3.0 versions:
 
-    * ``"+"`` is the only possible "separator" between main version part and any custom (local) part
-      (issuing warning for now if user wanted any other separator)
+  * Character ``"+"`` is used exclusively to demarcate the local part of the version
 
-    * ``local`` parts will be joined using ``"."`` character (will not make it configurable...)
+  * Character ``"."`` is used exclusively to demarcate local segments
+    (this is not configurable yet, and won't unless by popular request)
 
-    * ``local`` parts are always shown now, no need to use ``"!"`` character
-      (recommendation is: don't use local parts... but if you do, they'll always show up)
+  * The "main" part remains intact, except for ``devcommit``, furthermore only known PEP-440
+    "main version part" bits can ever be in the main part (anything that is mistakenly
+    specified to be in main part gets automatically shifted to the local part)
+
+  * "local" part is always shown now, no need to use ``"!"`` character (now deprecated),
+    except for ``{devcommit}`` and ``{dirty}`` markers, which will not lead to a local part
+    being shown when exactly on git tag.
+
+  * See [pep-440.rst](./docs/pep-440.rst) for more details
 
 
 2.9.0 (2021-03-15)
@@ -96,9 +100,9 @@ Release notes
 
 * Further refine hooks (#56)
 
-    * Add legacy hook to ease transition in rare cases.
+  * Add legacy hook to ease transition in rare cases.
 
-    * Ensure our dist finalization runs first.
+  * Ensure our dist finalization runs first.
 
 
 2.7.11 (2020-06-30)

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,24 @@ Release notes
 =============
 
 
+2.9.1 (2021-03-22)
+------------------
+
+* This is relatively large change, it could have justified a major version bump,
+  but the previous addition was relatively minor. So going to hold off on bumping major yet.
+  If you find an issue, please pin to prev version, or ``<2.9`` and report_
+
+* Yield PEP-440_ compliant versions:
+
+    * ``"+"`` is the only possible "separator" between main version part and any custom (local) part
+      (issuing warning for now if user wanted any other separator)
+
+    * ``local`` parts will be joined using ``"."`` character (will not make it configurable...)
+
+    * ``local`` parts are always shown now, no need to use ``"!"`` character
+      (recommendation is: don't use local parts... but if you do, they'll always show up)
+
+
 2.9.0 (2021-03-15)
 ------------------
 
@@ -425,3 +443,5 @@ Release notes
 .. _spark: https://spark.apache.org/docs/latest/index.html
 
 .. _PEP-440: https://www.python.org/dev/peps/pep-0440/#public-version-identifiers
+
+.. _report: https://github.com/codrsquad/setupmeta/issues

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -13,11 +13,11 @@ Release notes
   * Character ``"+"`` is used exclusively to demarcate the local part of the version
 
   * Character ``"."`` is used exclusively to demarcate local segments
-    (this is not configurable yet, and won't unless by popular request)
+    (this is not configurable yet, and won't be unless by popular request)
 
   * The "main" part remains intact, except for ``devcommit``, furthermore only known PEP-440
     "main version part" bits can ever be in the main part (anything that is mistakenly
-    specified to be in main part gets automatically shifted to the local part)
+    specified to be in the main part gets automatically shifted to the local part)
 
   * "local" part is always shown now, no need to use ``"!"`` character (now deprecated),
     except for ``{devcommit}`` and ``{dirty}`` markers, which will not lead to a local part

--- a/docs/pep-440.rst
+++ b/docs/pep-440.rst
@@ -1,0 +1,26 @@
+PEP-440 Compliance changes
+==========================
+
+``setupmeta`` v2.9.1 corrects yielded versions so they are PEP-440 compliant.
+
+This does change how yielded versions look like,
+especially if you use complex ones like ``build-id``.
+
+What remains unchanged
+======================
+
+The "main part" of your version will remain unchanged for all strategies except ``devcommit``.
+
+
+What's changed
+==============
+
+* ``devcommit``: ``.dev`` will NOT be alone anymore, but will yield a number indicating
+  the number of commits since last tag: ``.devN``).
+
+* ``build-id``, ``devcommit`` and any strategy that wants to show the "commit id":
+  the "local" part of your version will now **always** be shown
+
+* ``separator`` advanced argument is retired (you'll get a deprecation warning if you specify it)
+
+* Any separator other than ``"+"`` will generate a deprecation warning

--- a/docs/pep-440.rst
+++ b/docs/pep-440.rst
@@ -18,7 +18,7 @@ What's changed
 * ``devcommit``: ``.dev`` will NOT be alone anymore, but will yield a number indicating
   the number of commits since last tag: ``.devN``).
 
-* ``build-id``, ``devcommit`` and any strategy that wants to show the "commit id":
+* ``build-id`` and any strategy that wants to show the "commit id":
   the "local" part of your version will now **always** be shown
 
 * ``separator`` advanced argument is retired (you'll get a deprecation warning if you specify it)

--- a/docs/requirements.rst
+++ b/docs/requirements.rst
@@ -22,9 +22,9 @@ if the following applies to you:
 
 - you agree with this `community recommendation`_, ie:
 
-    - in general your **install_requires** should not be pinning dependencies to specific versions
+  - in general your **install_requires** should not be pinning dependencies to specific versions
 
-    - you may want to pin to specific versions when building/packaging (in ``requirements.txt``)
+  - you may want to pin to specific versions when building/packaging (in ``requirements.txt``)
 
 
 How it works
@@ -34,16 +34,16 @@ Setupmeta auto-fills dependency/requirements from the contents of the following 
 
 - **install_requires** from:
 
-    - ``requirements.txt`` (recommended)
+  - ``requirements.txt`` (recommended)
 
-    - ``pinned.txt``
+  - ``pinned.txt``
 
 - **tests_require** from:
 
-    - ``tests/requirements.txt`` (recommended)
-    - ``requirements-dev.txt``
-    - ``dev-requirements.txt``
-    - ``test-requirements.txt``
+  - ``tests/requirements.txt`` (recommended)
+  - ``requirements-dev.txt``
+  - ``dev-requirements.txt``
+  - ``test-requirements.txt``
 
 Your requirement file is parsed and used to auto-fill the **install_requires**
 or **tests_require** section:
@@ -52,19 +52,19 @@ or **tests_require** section:
 
 - there are 3 categories of dependencies that setupmeta will consider:
 
-    - **abstract**: (default) minimal dependency, not bound to any specific version,
-      example: ``requests``
+  - **abstract**: (default) minimal dependency, not bound to any specific version,
+    example: ``requests``
 
-    - **pinned**: explicit dependency, example: ``requests==2.19.1``
+  - **pinned**: explicit dependency, example: ``requests==2.19.1``
 
-    - **indirect**: transitive dependency, not mentioned in **install_requires**,
-      but will be pinned to a specific version when building/packaging
+  - **indirect**: transitive dependency, not mentioned in **install_requires**,
+    but will be pinned to a specific version when building/packaging
 
 - abstracting away applies only to simple ``==`` pinning, and nothing else, ie:
 
-    - ``click==6.7`` will be abstracted as click
+  - ``click==6.7`` will be abstracted as click
 
-    - however ``click>=6.7`` will not be abstracted in any case
+  - however ``click>=6.7`` will not be abstracted in any case
 
 - sections of ``requirements.txt`` (or equivalent) can be marked via a comment line,
   all entries below that line (and up to next section) will have the stated category,

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -12,10 +12,10 @@ The functionality is optional and has to be explicitly enabled, note that:
 
 * It can be a drop-in replacement for setuptools_scm_
 
-* 3 strategies are pre-configured: post_, distance_ and build-id_,
+* 5 strategies are pre-configured: post_, dev_, distance_, devcommit_ and build-id_,
   they yield versions that play well with PEP-440_ (while remaining very simple).
 
-* See Advanced_ for more info
+* See Advanced_ section for more info
 
 In order to use setupmeta as a bridge to your git tags as versions,
 activate the feature by specifying one of the strategies in your ``setup.py`` like so::
@@ -125,7 +125,7 @@ post
 
 This is well suited if you don't plan to publish often, and have a tag for each release.
 
-``post`` corresponds to this format: ``branch(master):{major}.{minor}.{patch}{post}{dirty}``
+``post`` corresponds to this format: ``branch(main,master):{major}.{minor}.{patch}{post}+{dirty}``
 
 State this in your ``setup.py``::
 
@@ -146,7 +146,7 @@ Commit   Tag     Version            Note (command ran to add tag)
 no .git          0.0.0              Version defaults to 0.0.0 (when no tag yet)
 none             0.0.0.dirty        No commit yet (but ``git init`` was ran)
 g1               0.0.0.post1        Initial commit
-g1               0.0.0.post1.dirty  Same as above, only checkout was not clean anymore
+g1               0.0.0.post1+dirty  Same as above, only checkout was not clean anymore
 g2               0.0.0.post2
 g3               0.0.0.post3
 g4       v0.1.0  0.1.0              ``version --bump minor --commit``
@@ -168,7 +168,7 @@ g10              1.0.0.post1
 
 * A 2nd commit doesn't add a git tag, version for that commit will be ``0.1.0.post2`` etc
 
-* Dirty checkouts will get a version of the form ``0.1.0.post2.dirty``
+* Dirty checkouts will get a version of the form ``0.1.0.post2+dirty``
 
 * Use ``python setup.py version --bump [major|minor|patch]`` whenever you want to bump major,
   minor or patch revision (this will assign a git tag accordingly)
@@ -184,8 +184,8 @@ dev
 
 Similar to post_, with the following differences:
 
-- ``.dev`` prefix is used instead of ``post``, this makes untagged versions considered pre-release
-  (have to use ``pip install --pre`` to get them)
+- ``.dev`` prefix is used instead of ``.post``, this makes untagged versions considered
+  pre-release (have to use ``pip install --pre`` to get them)
 
 - right-most bumpable component (typically **patch**) is assumed to be the next one
   that is going to be bumped... (this just means that if your current version is ``0.8.1``,
@@ -198,9 +198,9 @@ Example:
 Commit   Tag     Version           Note (command ran to add tag)
 =======  ======  ================  ===============================================================
 no .git          0.0.0.dev0        Version defaults to 0.0.0 (when no tag yet)
-none             0.0.0.dev0.dirty  No commit yet (but ``git init`` was ran)
+none             0.0.0.dev0+dirty  No commit yet (but ``git init`` was ran)
 g1               0.0.0.dev1        Initial commit
-g1               0.0.0.dev1.dirty  Same as above, only checkout was not clean anymore
+g1               0.0.0.dev1+dirty  Same as above, only checkout was not clean anymore
 g2               0.0.0.dev2
 g3               0.0.0.dev3
 g4       v0.1.0  0.1.0             ``version --bump minor --commit``
@@ -215,25 +215,25 @@ g10              1.0.0.dev1
 devcommit
 ---------
 
-Similar to dev_, except that it uses the commit id instead of distance.
+Same as dev_, with commit id **always** added as ``local`` part (of yielded version).
 
 Example:
 
-=======  ======  ==================  =============================================================
-Commit   Tag     Version             Note (command ran to add tag)
-=======  ======  ==================  =============================================================
-g1               0.0.0.dev-g1        Initial commit
-g1               0.0.0.dev-g1-dirty  Same as above, only checkout was not clean anymore
-g2               0.0.0.dev-g2
-g3               0.0.0.dev-g3
-g4       v0.1.0  0.1.0               ``version --bump minor --commit``
-g5               0.1.1.dev-g5        (1 commit since tag)
-g6               0.1.1.dev-g6
-g7       v0.1.1  0.1.1               ``version --bump patch --commit``
-g8               0.1.2.dev-g7
-g9       v1.0.0  1.0.0               ``version --bump major --commit``
-g10              1.0.0.dev-g10
-=======  ======  ==================  =============================================================
+=======  ======  ===================  ============================================================
+Commit   Tag     Version              Note (command ran to add tag)
+=======  ======  ===================  ============================================================
+g1               0.0.0.dev1+g1        Initial commit
+g1               0.0.0.dev1+g1.dirty  Same as above, only checkout was not clean anymore
+g2               0.0.0.dev2+g2
+g3               0.0.0.dev3+g3
+g4       v0.1.0  0.1.0+g4             ``version --bump minor --commit``
+g5               0.1.1.dev1+g5        (1 commit since tag)
+g6               0.1.1.dev2+g6
+g7       v0.1.1  0.1.1+g7             ``version --bump patch --commit``
+g8               0.1.2.dev1+g7
+g9       v1.0.0  1.0.0+g9             ``version --bump major --commit``
+g10              1.0.0.dev1+g10
+=======  ======  ===================  ============================================================
 
 
 distance
@@ -242,7 +242,7 @@ distance
 This is well suited if you want to publish a new version at every commit (but don't want to keep
 bumping version in code for every commit).
 
-``distance`` corresponds to this format: ``branch(master):{major}.{minor}.{distance}{dirty}``
+``distance`` corresponds to this format: ``branch(main,master):{major}.{minor}.{distance}{dirty}``
 
 State this in your ``setup.py``::
 
@@ -262,9 +262,9 @@ Example:
 Commit   Tag     Version           Note (command ran to add tag)
 =======  ======  ================  ===============================================================
 no .git          0.0.0             Version defaults to 0.0 (when no tag yet)
-none             0.0.0.dirty       No commit yet (but ``git init`` was ran)
+none             0.0.0+dirty       No commit yet (but ``git init`` was ran)
 g1               0.0.1             Initial commit, 0.0.1 means default v0.0 + 1 change
-g1               0.0.1.dirty       Same as above, only checkout was not clean anymore
+g1               0.0.1+dirty       Same as above, only checkout was not clean anymore
 g2               0.0.2
 g3               0.0.3
 g4       v0.1.0  0.1.0             ``setup.py version --bump minor --commit``
@@ -288,7 +288,7 @@ g11              1.0.1
 
 * A 2nd commit occurs and doesn't add a git tag, version for that commit will be ``0.1.2`` etc
 
-* Dirty checkouts will get a version of the form ``0.1.2.dirty``
+* Dirty checkouts will get a version of the form ``0.1.2+dirty``
 
 * Use ``python setup.py version --bump [major|minor]`` whenever you want to bump major
   or minor version (this will assign a git tag accordingly)
@@ -306,7 +306,7 @@ This is similar to distance_ (described above), so well suited if you want to pu
 version at every commit, but also want maximum info in the version identifier.
 
 ``build-id`` corresponds to this format:
-``branch(master):{major}.{minor}.{distance}+!h{$*BUILD_ID:local}.{commitid}{dirty}``
+``branch(main,master):{major}.{minor}.{distance}+h{$*BUILD_ID:local}.{commitid}{dirty}``
 
 State this in your ``setup.py``::
 
@@ -321,7 +321,7 @@ Example:
 =======  ======  ===========================  ====================================================
 Commit   Tag     Version                      Note (command ran to add tag)
 =======  ======  ===========================  ====================================================
-no .git          0.0.0                        Version defaults to 0.0 (when no tag yet)
+no .git          0.0.0+hlocal.g0000000        Version defaults to 0.0 (when no tag yet)
 none             0.0.0+hlocal.g0000000.dirty  No commit yet (but ``git init`` was ran)
 g1               0.0.1+hlocal.g1              Initial commit, built locally
                                               (``$BUILD_ID`` not defined), checkout was clean
@@ -344,9 +344,6 @@ g10              1.0.1+h300.g3
 * Similar to distance_, except that the ``extra`` part is always shown and will reflect whether
 build took locally or on a CI server (which will define an env var ending with ``BUILD_ID``)
 
-* Can be easily made to act like post_ instead for the **main*** part of the version via
-``versioning="post+build-id"``
-
 
 Advanced
 ========
@@ -357,39 +354,28 @@ or a **dict** for even more customization:
 
 * a **string** can be of the form:
 
-    * One of the pre-configured formats above, or a meaningful combination like ``post+build-id``
-      (the part after the ``"+"`` will be used to determine strategy for ``extra`` part only)
-
-    * a version format specified of the form ``branch(<branches>):<main><separator><extra>``
+    * a version format specified of the form ``branch(<branches>):<main>+<extra>``
 
     * ``branch(<branches>):`` is optional, and you would use this full form only if you wanted
-      version bumps to be possible on branches other than master, if you want bumps to be
-      possible on both ``master`` and ``test`` branches for example,
-      you would use ``branch(master,test):...``
+      version bumps to be possible on branches other than ``main`` or ``master``,
+      if you want bumps to be possible on both ``prod`` and ``test`` branches for example,
+      you would use ``branch(prod,test):...``
 
     * See Formatting_ below to see what's usable for ``<main>`` and ``<extra>``
 
-    * the ``<main>`` part (before the ``<separator>`` sign) specifies the format of the
+    * the ``<main>`` part (before the ``"+"`` character) specifies the format of the
       "main version" part (when checkout is clean)
 
-    * the ``<extra>`` part (after the ``<separator>`` sign indicates) what format to use when
-      there checkout is dirty
-
-    * you can add an exclamation point ``"!"`` after separator to force the extra part to
-      always be shown (even when checkout is not dirty)
-
-    * characters that can be used as separators are: `` +@#%^/`` (space can be used as a
-      demarcation, but will not be rendered in the version per se)
+    * the ``<extra>`` part (after the ``"+"`` character) indicates the ``local`` part of
+      your version, as per PEP-440_
 
 * a **dict** with the following keys:
 
-    * ``main``: a **string** (see Formatting_) or callable (if callable given,
-      **version --bump** functionality becomes unusable)
+    * ``main``: a **string** (see Formatting_) or callable
+      (if callable given, **version --bump** functionality becomes unusable)
 
     * ``extra``: a **string** (see Formatting_) or callable (custom function yielding
       a string from a given ``Version``, see `Scm class`_)
-
-    * ``separator``: character to use as separator between ``main`` and ``extra``
 
     * ``branches``: list of branch names (or csv) where to allow **bump**
 
@@ -400,8 +386,7 @@ This is what ``versioning="post"`` is a shortcut for::
         versioning={
             "main": "{major}.{minor}.{patch}{post}",
             "extra": "{dirty}",
-            "branches": ["master"],
-            "separator": ""
+            "branches": ["main"],
         },
         ...
     )
@@ -421,16 +406,16 @@ The following can be used as format specifiers:
 * ``{distance}``: Number of commits since last version tag from current commit
   (0 if current commit is tagged)
 
-* ``{post}``: Designates a "post" release (PEP-440_ friendly), empty when current commit
+* ``{post}``: Designates a "post" release, empty when current commit
   is version-tagged, otherwise ``.postN`` (where ``"N"`` is ``{distance}``)
 
-* ``{dev}``: Designates a "dev" release (PEP-440_ friendly), empty when current commit is
+* ``{dev}``: Designates a "dev" release, empty when current commit is
   version-tagged, otherwise ``[+1].devN`` (where ``"N"`` is ``{distance}``, a ``[+1]`` is
   the next revision of the right-most bumpable, usually ``patch``).
   Example: ``1.2.dev3``.
 
-* ``{devcommit}``: Same as ``{dev}``, but with commit id instead of distance.
-  Example: ``1.2.dev-g12345``.
+* ``{devcommit}``: Same as ``{dev}``, with commit id in ``local`` version part.
+  Example: ``1.2.dev3+g12345``.
 
 * ``{commitid}``: short string identifying commit, like ``g3bf9221``
 
@@ -444,9 +429,7 @@ The following can be used as format specifiers:
 * ``{$BUILD_ID:local}``: value of environment variable ``BUILD_ID`` if defined,
   constant ``local`` otherwise
 
-* generalized env var spec is: ``{prefix$*FOO*:default}``:
-
-    * ``prefix`` is shown only if any env var containing ``FOO`` in this case is defined
+* generalized env var spec is: ``{$*FOO*:default}``:
 
     * ``$FOO`` will look for env var ``FOO`` exactly
 
@@ -456,50 +439,7 @@ The following can be used as format specifiers:
 
     * ``$*FOO*`` will use the first (alphabetically sorted) env var that contains ``FOO``
 
-    * ``default`` will be shown if no corresponding env var is defined
-
-
-Examples
-========
-
-* ``{major}.{minor}.{patch}{post}+h{$BUILD_ID:local}.{commitid}`` will yield versions like:
-
-    * ``1.0.0`` (clean, on tag)
-
-    * ``1.0.0.post1`` (clean, one commit since tag)
-
-    * ``1.0.0.post1+hlocal.g123`` (dirty, no $BUILD_ID)
-
-    * ``1.0.0.post1+h123.g123`` (dirty, with $BUILD_ID)
-
-
-* ``{major}.{minor}.{patch}{post}+!h{$BUILD_ID:local}.{commitid}`` would be the same as above,
-  but ``extra`` part **always** shown (due to the ``"!"`` character):
-
-    * ``1.0.0+hlocal.g123`` (clean, on tag, no $BUILD_ID)
-
-    * ``1.0.0.post1+h123.g123`` (clean, one commit since tag, with $BUILD_ID)
-
-    * ``1.0.0.post1+hlocal.g123`` (dirty, no $BUILD_ID)
-
-    * ``1.0.0.post1+h123.g123`` (dirty, with $BUILD_ID)
-
-
-* ``{major}.{minor}.{distance} .{commitid}``: space demarcates ``main`` vs ``extra``,
-  but is not added in the final version render
-
-    * ``1.0.0`` (clean, on tag)
-
-    * ``1.0.1`` (clean, one commit since tag)
-
-    * ``1.0.1.g123`` (dirty, note: no space between ``1.0.1`` ("main" part) and ``.g123``
-      ("extra" part))
-
-
-* ``{major}.{minor}.{distance}.{commitid}``: similar to above, except here there is no separator,
-  and hence no ``extra`` part (the ``.{commitid}`` is part of **main** part and will be always
-  rendered, so equivalent to above with exclamation point, like:
-  ``{major}.{minor}.{distance} !.{commitid}``)
+    * ``default`` will be shown if no env var could be found
 
 
 .. _PEP-440: https://www.python.org/dev/peps/pep-0440/

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -215,7 +215,7 @@ g10              1.0.0.dev1
 devcommit
 ---------
 
-Same as dev_, with commit id **always** added as ``local`` part (of yielded version).
+Same as dev_, with commit id added in ``local`` part when not exactly on a version tag.
 
 Example:
 
@@ -226,12 +226,12 @@ g1               0.0.0.dev1+g1        Initial commit
 g1               0.0.0.dev1+g1.dirty  Same as above, only checkout was not clean anymore
 g2               0.0.0.dev2+g2
 g3               0.0.0.dev3+g3
-g4       v0.1.0  0.1.0+g4             ``version --bump minor --commit``
+g4       v0.1.0  0.1.0                ``version --bump minor --commit``
 g5               0.1.1.dev1+g5        (1 commit since tag)
 g6               0.1.1.dev2+g6
-g7       v0.1.1  0.1.1+g7             ``version --bump patch --commit``
+g7       v0.1.1  0.1.1                ``version --bump patch --commit``
 g8               0.1.2.dev1+g7
-g9       v1.0.0  1.0.0+g9             ``version --bump major --commit``
+g9       v1.0.0  1.0.0                ``version --bump major --commit``
 g10              1.0.0.dev1+g10
 =======  ======  ===================  ============================================================
 
@@ -414,7 +414,7 @@ The following can be used as format specifiers:
   the next revision of the right-most bumpable, usually ``patch``).
   Example: ``1.2.dev3``.
 
-* ``{devcommit}``: Same as ``{dev}``, with commit id in ``local`` version part.
+* ``{devcommit}``: Same as ``{dev}``, with commit id added in ``local`` version part.
   Example: ``1.2.dev3+g12345``.
 
 * ``{commitid}``: short string identifying commit, like ``g3bf9221``

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -173,10 +173,10 @@ g10              1.0.0.post1
 * Use ``python setup.py version --bump [major|minor|patch]`` whenever you want to bump major,
   minor or patch revision (this will assign a git tag accordingly)
 
-    * ``python setup.py version --bump patch --commit`` -> tag "v0.1.1" is added,
-      version is now ``0.1.1``
+  * ``python setup.py version --bump patch --commit`` -> tag "v0.1.1" is added,
+    version is now ``0.1.1``
 
-    * Next commit after that will be version ``0.1.1.post1`` etc
+  * Next commit after that will be version ``0.1.1.post1`` etc
 
 
 dev
@@ -184,10 +184,10 @@ dev
 
 Similar to post_, with the following differences:
 
-- ``.dev`` prefix is used instead of ``.post``, this makes untagged versions considered
+* ``.dev`` prefix is used instead of ``.post``, this makes untagged versions considered
   pre-release (have to use ``pip install --pre`` to get them)
 
-- right-most bumpable component (typically **patch**) is assumed to be the next one
+* Right-most bumpable component (typically **patch**) is assumed to be the next one
   that is going to be bumped... (this just means that if your current version is ``0.8.1``,
   you would get a ``0.8.2.dev1`` etc; even though you may be planning your next tag to be
   ``0.9.0``, and not ``0.8.2``)
@@ -293,10 +293,10 @@ g11              1.0.1
 * Use ``python setup.py version --bump [major|minor]`` whenever you want to bump major
   or minor version (this will assign a git tag accordingly)
 
-    * ``python setup.py version --bump minor --commit`` -> tag "v0.2" is added,
-      version is now ``0.2.0``
+  * ``python setup.py version --bump minor --commit`` -> tag "v0.2" is added,
+    version is now ``0.2.0``
 
-    * Next commit after that will be version ``0.2.1`` etc
+  * Next commit after that will be version ``0.2.1`` etc
 
 
 build-id
@@ -342,7 +342,7 @@ g10              1.0.1+h300.g3
 =======  ======  ===========================  ====================================================
 
 * Similar to distance_, except that the ``extra`` part is always shown and will reflect whether
-build took locally or on a CI server (which will define an env var ending with ``BUILD_ID``)
+  build took locally or on a CI server (which will define an env var ending with ``BUILD_ID``)
 
 
 Advanced
@@ -354,30 +354,30 @@ or a **dict** for even more customization:
 
 * a **string** can be of the form:
 
-    * a version format specified of the form ``branch(<branches>):<main>+<extra>``
+  * a version format specified of the form ``branch(<branches>):<main>+<extra>``
 
-    * ``branch(<branches>):`` is optional, and you would use this full form only if you wanted
-      version bumps to be possible on branches other than ``main`` or ``master``,
-      if you want bumps to be possible on both ``prod`` and ``test`` branches for example,
-      you would use ``branch(prod,test):...``
+  * ``branch(<branches>):`` is optional, and you would use this full form only if you wanted
+    version bumps to be possible on branches other than ``main`` or ``master``,
+    if you want bumps to be possible on both ``prod`` and ``test`` branches for example,
+    you would use ``branch(prod,test):...``
 
-    * See Formatting_ below to see what's usable for ``<main>`` and ``<extra>``
+  * See Formatting_ below to see what's usable for ``<main>`` and ``<extra>``
 
-    * the ``<main>`` part (before the ``"+"`` character) specifies the format of the
-      "main version" part (when checkout is clean)
+  * the ``<main>`` part (before the ``"+"`` character) specifies the format of the
+    "main version" part (when checkout is clean)
 
-    * the ``<extra>`` part (after the ``"+"`` character) indicates the ``local`` part of
-      your version, as per PEP-440_
+  * the ``<extra>`` part (after the ``"+"`` character) indicates the ``local`` part of
+    your version, as per PEP-440_
 
 * a **dict** with the following keys:
 
-    * ``main``: a **string** (see Formatting_) or callable
-      (if callable given, **version --bump** functionality becomes unusable)
+  * ``main``: a **string** (see Formatting_) or callable
+    (if callable given, **version --bump** functionality becomes unusable)
 
-    * ``extra``: a **string** (see Formatting_) or callable (custom function yielding
-      a string from a given ``Version``, see `Scm class`_)
+  * ``extra``: a **string** (see Formatting_) or callable (custom function yielding
+    a string from a given ``Version``, see `Scm class`_)
 
-    * ``branches``: list of branch names (or csv) where to allow **bump**
+  * ``branches``: list of branch names (or csv) where to allow **bump**
 
 
 This is what ``versioning="post"`` is a shortcut for::
@@ -414,13 +414,25 @@ The following can be used as format specifiers:
   the next revision of the right-most bumpable, usually ``patch``).
   Example: ``1.2.dev3``.
 
-* ``{devcommit}``: Same as ``{dev}``, with commit id added in ``local`` version part.
+* ``{devcommit}``: Same as ``{dev}``, with commit id added in ``local`` version part
+  when not exactly on version tag.
   Example: ``1.2.dev3+g12345``.
 
 * ``{commitid}``: short string identifying commit, like ``g3bf9221``
 
 * ``{dirty}``: Expands to ``.dirty`` when checkout is dirty (has pending changes),
   empty string otherwise
+
+* Convenience notations: the following shortcuts can be used for the local part of the
+  version:
+
+  * ``+devcommit``: Use the stated strategy, but add ``{devcommit}`` to the local part
+
+  * ``+build-id``: Use the stated strategy, but add the same info from build-id_ strategy
+      to the local part
+
+  * Example: ``dev+devcommit``, or ``post+build-id`` etc
+
 
 * ``foo``: constant ``foo`` (used as-is if specified)
 
@@ -431,15 +443,15 @@ The following can be used as format specifiers:
 
 * generalized env var spec is: ``{$*FOO*:default}``:
 
-    * ``$FOO`` will look for env var ``FOO`` exactly
+  * ``$FOO`` will look for env var ``FOO`` exactly
 
-    * ``$*FOO`` will use the first (alphabetically sorted) env var that ends with ``FOO``
+  * ``$*FOO`` will use the first (alphabetically sorted) env var that ends with ``FOO``
 
-    * ``$FOO*`` will use the first (alphabetically sorted) env var that starts with ``FOO``
+  * ``$FOO*`` will use the first (alphabetically sorted) env var that starts with ``FOO``
 
-    * ``$*FOO*`` will use the first (alphabetically sorted) env var that contains ``FOO``
+  * ``$*FOO*`` will use the first (alphabetically sorted) env var that contains ``FOO``
 
-    * ``default`` will be shown if no env var could be found
+  * ``default`` will be shown if no env var could be found
 
 
 .. _PEP-440: https://www.python.org/dev/peps/pep-0440/

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -303,11 +303,8 @@ class Version:
     @property
     def devcommit(self):
         """
-        {devcommit} marker for this version
+        {devcommit} marker for this version, alias for ".{commitid}"
 
-        :return str: '.dev{distance}-{commitid}' for distance > 0, empty string otherwise
+        :return str: '.{commitid}' for distance > 0, empty string otherwise
         """
-        if self.distance or self.dirty:
-            return "%s.dev%d-%s" % (self.additional, self.distance, self.commitid)
-
-        return self.additional
+        return ".%s" % self.commitid

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -307,4 +307,7 @@ class Version:
 
         :return str: '.{commitid}' for distance > 0, empty string otherwise
         """
-        return ".%s" % self.commitid
+        if self.distance or self.dirty:
+            return ".%s" % self.commitid
+
+        return ""

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -36,13 +36,11 @@ class Scm:
         """
         :return str: Current branch name
         """
-        pass
 
     def get_version(self):
         """
         :return Version: Current version as computed from latest SCM version tag
         """
-        pass
 
     def commit_files(self, commit, push, relative_paths, next_version):
         """
@@ -53,7 +51,6 @@ class Scm:
         :param list(str) relative_paths: Relative paths to commit
         :param str next_version: Version that is about to be applied, of the form 1.0.0 (used for commit message)
         """
-        pass
 
     def apply_tag(self, commit, push, next_version, branch):
         """
@@ -64,7 +61,6 @@ class Scm:
         :param str next_version: Version to use for tag
         :param str branch: Branch on which tag is being applied
         """
-        pass
 
     def get_output(self, *args, **kwargs):
         """
@@ -107,9 +103,7 @@ class Snapshot(Scm):
 
     def is_dirty(self):
         v = os.environ.get(setupmeta.SCM_DESCRIBE)
-        if v and "dirty" in v:
-            return True
-        return False
+        return v and "dirty" in v
 
     def get_branch(self):
         """Consider branch to be always HEAD for snapshots"""
@@ -119,6 +113,7 @@ class Snapshot(Scm):
         v = os.environ.get(setupmeta.SCM_DESCRIBE)
         if v:
             return Git.parsed_version(v)
+
         path = os.path.join(self.root, setupmeta.VERSION_FILE)
         with open(path) as fh:
             return Git.parsed_version(fh.readline(), False)
@@ -138,6 +133,7 @@ class Git(Scm):
             tag = str(p.partition("^")[0])
             if tag.startswith("v") or tag[0].isdigit():
                 result.add(tag)
+
         return result
 
     def local_tags(self):
@@ -160,7 +156,9 @@ class Git(Scm):
                 if dirty is None:
                     # This is only settable via env var SCM_DESCRIBE
                     dirty = m.group(4) == "-dirty"
+
                 return Version(main, distance, commitid, dirty, text)
+
         return None
 
     def is_dirty(self):
@@ -173,6 +171,7 @@ class Git(Scm):
         exitcode = self.get_output("diff", "--quiet", "--ignore-submodules", capture=False)
         if exitcode == 0:
             exitcode = self.get_output("diff", "--quiet", "--ignore-submodules", "--staged", capture=False)
+
         return exitcode != 0
 
     def get_branch(self):
@@ -199,6 +198,7 @@ class Git(Scm):
     def has_origin(self):
         if self._has_origin is None:
             self._has_origin = bool(self.get_output("config", "--get", "remote.origin.url"))
+
         return self._has_origin
 
     def commit_files(self, commit, push, relative_paths, next_version):
@@ -211,6 +211,7 @@ class Git(Scm):
         if push:
             if self.has_origin():
                 self.run(commit, "push", "origin")
+
             else:
                 print("Won't push: no origin defined")
 
@@ -229,7 +230,6 @@ class Git(Scm):
         tag = "v%s" % next_version
 
         self.run(commit, "tag", "-a", tag, "-m", bump_msg)
-
         if push:
             if self.has_origin():
                 self.run(commit, "push", "--tags", "origin")

--- a/setupmeta/versioning.py
+++ b/setupmeta/versioning.py
@@ -410,7 +410,12 @@ def _parsed_extra(given, default):
         if not given:
             return given
 
+    if given == "devcommit":
+        # Allow for convenience notation of the form "dev+devcommit" or "post+devcommit" etc
+        return "{devcommit}{dirty}"
+
     if given == "build-id":
+        # Allow for convenience notation of the form "dev+build-id" or "post+build-id" etc
         return "h{$*BUILD_ID:local}.{commitid}{dirty}"
 
     return given

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 mock  # Won't be needed anymore when py2 support is dropped
+pep440
 pytest-cov
 six

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -187,6 +187,18 @@ def test_versioning_variants(*_):
         quick_check("1.2.3", "1.2.3+dirty")
         quick_check("foo", "foo+dirty")
 
+        quick_check("dev+{commitid}{dirty}", "0.1.3.dev5+g123.dirty")
+        quick_check("dev+{commitid}{dirty}", "0.1.3.dev0+g123.dirty", describe="v0.1.2-0-g123")
+        quick_check("dev+{commitid}{dirty}", "0.1.2+g123", describe="v0.1.2-0-g123", dirty=False)
+
+        quick_check("dev+devcommit", "0.1.3.dev5+g123.dirty")
+        quick_check("dev+devcommit", "0.1.3.dev0+g123.dirty", describe="v0.1.2-0-g123")
+        quick_check("dev+devcommit", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
+
+        quick_check("post+devcommit", "0.1.2.post5+g123.dirty")
+        quick_check("post+devcommit", "0.1.2+g123.dirty", describe="v0.1.2-0-g123")
+        quick_check("post+devcommit", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
+
         quick_check("dev", "0.1.9rc1", dirty=False, describe="v0.1.9-rc.1-0-gebe2789")
         quick_check("devcommit", "0.1.9rc1", dirty=False, describe="v0.1.9-rc.1-0-gebe2789")
         quick_check("post", "0.1.9rc1+dirty", dirty=True, describe="v0.1.9-rc.1-0-gebe2789")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -188,7 +188,7 @@ def test_versioning_variants(*_):
         quick_check("foo", "foo+dirty")
 
         quick_check("dev", "0.1.9rc1", dirty=False, describe="v0.1.9-rc.1-0-gebe2789")
-        quick_check("devcommit", "0.1.9rc1+gebe2789", dirty=False, describe="v0.1.9-rc.1-0-gebe2789")
+        quick_check("devcommit", "0.1.9rc1", dirty=False, describe="v0.1.9-rc.1-0-gebe2789")
         quick_check("post", "0.1.9rc1+dirty", dirty=True, describe="v0.1.9-rc.1-0-gebe2789")
 
         quick_check("dev", "0.1.9rc1.dev1", dirty=False, describe="v0.1.9-rc.1-1-gebe2789")
@@ -213,8 +213,9 @@ def test_versioning_variants(*_):
         # On tag
         quick_check("dev", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
         quick_check("dev", "0.1.3.dev0+dirty", describe="v0.1.2-0-g123", dirty=True)
-        quick_check("devcommit", "0.1.2+g0000000", describe="v0.1.2", dirty=False)
-        quick_check("devcommit", "0.1.2+g123", describe="v0.1.2-0-g123", dirty=False)
+        quick_check("devcommit", "0.1.2", describe="v0.1.2", dirty=False)
+        quick_check("devcommit", "0.1.2", describe="v0.1.2-0-g123", dirty=False)
+        quick_check("devcommit", "0.1.3.dev7+g123", describe="v0.1.2-7-g123", dirty=False)
         quick_check("devcommit", "0.1.3.dev0+g123.dirty", describe="v0.1.2-0-g123", dirty=True)
 
         assert "patch version component should be .0" in logged


### PR DESCRIPTION
Changes explained in docs/pep-440.rst

`pip wheel` started requiring that versions be PEP-440 compliant.
This ensures that setupmeta generates such versions.
Unfortunately, it does change how some versioning strategies are rendered, but the changes should be limited to how the "local" part of the PEP-440 version is rendered only.
