### PR TITLE
Provide a way to specify git version tag form

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,9 @@ jobs:
       run: twine upload dist/*
 
   publish-eol-eggs:
-    # Last ditch effort to publish eggs for ancient python versions
+    # Last ditch effort to publish eggs for ancient python versions (this may be refused by pypi, retire such versions then)
 
-    needs: publish-wheel
+    needs: publish-eggs
     runs-on: ubuntu-20.04
 
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,31 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - run: pip install -U pip setuptools wheel twine
+    - run: python setup.py bdist_egg
+    - name: Publish egg
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.SETUPMETA_TOKEN }}
+      run: twine upload dist/*
+
+  publish-eol-eggs:
+    # Last ditch effort to publish eggs for ancient python versions
+
+    needs: publish-wheel
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.6']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,31 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['2.7', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - run: |
+        pip install -U pip tox
+        git config --global user.name tester
+        git config --global user.email tester@example.com
+    - run: tox -e py
+    - uses: codecov/codecov-action@v1
+      with:
+        file: .tox/test-reports/coverage.xml
+
+  test-eol:
+    # EOL-ed versions of python are exercised on older linux distros
+    # Testing against these versions will eventually be retired
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.6']
 
     steps:
     - uses: actions/checkout@v2

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,24 @@
 Release notes
 =============
 
+3.3.3 (2023-01-25)
+------------------
+
+* Allow to configure format of git version tag
+
+
+3.3.2 (2022-06-01)
+------------------
+
+* Protect against hook setup call in ancient setuptools versions
+
+
+3.3.1 (2022-05-04)
+------------------
+
+* Test with 3.10, publish sdist with 3.9
+
+
 3.3.0 (2021-06-14)
 ------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,10 +2,18 @@
 Release notes
 =============
 
-3.3.3 (2023-01-25)
+3.4.0 (2023-01-25)
 ------------------
 
-* Allow to configure format of git version tag
+* Allow to configure format of git version tag via the advanced dict-form of ``versioning``,
+  example::
+
+    versioning={
+        "main": "{major}.{minor}.{distance}",
+        "extra": "{dirty}",
+        "branches": "master",
+        "version_tag": "v*.*",
+    },
 
 
 3.3.2 (2022-06-01)

--- a/docs/versioning.rst
+++ b/docs/versioning.rst
@@ -387,9 +387,20 @@ This is what ``versioning="post"`` is a shortcut for::
             "main": "{major}.{minor}.{patch}{post}",
             "extra": "{dirty}",
             "branches": ["main"],
+            "version_tag": "*.*",
         },
         ...
     )
+
+``version_tag`` is the glob pattern of git tags to consider as version tags.
+Unfortunately (for historical reasons), the default form is ``*.*`` (ie: any git tag
+with a dot in it), and arguably should have been ``v*.*`` (ie: git tags that start with ``v``
+and have dot in them...)
+
+Ideally, git would allow to state a full regex, as only tags that match this regex
+would ideally be considered as version tags: ``^v?\d+\.\d+(\.\d+)?$``, however this is not
+possible with git (if it is possible, setupmeta will be upgraded to simplify things by using
+this regex, in which case the ``version_tag`` setting will be sunset).
 
 
 Formatting

--- a/examples/single/expected.txt
+++ b/examples/single/expected.txt
@@ -38,7 +38,7 @@ setup(
 )
 
 :: check
-warning: CheckCommand: missing required meta-data: url
+
 
 :: entrypoints
 

--- a/examples/via-cfg/expected.txt
+++ b/examples/via-cfg/expected.txt
@@ -39,7 +39,7 @@ setup(
 )
 
 :: check
-warning: CheckCommand: missing required meta-data: url
+
 
 :: entrypoints
 pytest=pytest:main

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ if __name__ == "__main__":
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
+            "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: Implementation :: CPython",
             "Programming Language :: Python :: Implementation :: PyPy",
             "Topic :: Software Development :: Build Tools",

--- a/setupmeta/model.py
+++ b/setupmeta/model.py
@@ -533,6 +533,9 @@ class SetupMeta(Settings):
 
         scm = scm or project_scm(MetaDefs.project_dir)
         self.versioning = Versioning(self, scm)
+        if scm and self.versioning.strategy and self.versioning.strategy.version_tag:
+            scm.version_tag = self.versioning.strategy.version_tag
+
         self.versioning.auto_fill_version()
 
         self.fill_urls()

--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -12,6 +12,7 @@ class Scm:
     """API used by setupmeta for versioning using SCM tags"""
 
     program = None  # type: str # Program name (like 'git' or 'hg')
+    version_tag = None  # type: str # Format for tags to consider as version tags in underlying SCM, when applicable
 
     def __init__(self, root):
         """
@@ -181,7 +182,12 @@ class Git(Scm):
     def get_version(self):
         dirty = self.is_dirty()
         # Allow to override git describe command via env var SETUPMETA_GIT_DESCRIBE_COMMAND (just in case)
-        cmd = os.environ.get("SETUPMETA_GIT_DESCRIBE_COMMAND", "describe --dirty --tags --long --match *.* --first-parent")
+        cmd = os.environ.get("SETUPMETA_GIT_DESCRIBE_COMMAND")
+        if not cmd:
+            # TODO: Consider changing the default version tag to be of the form `v*.*` instead
+            version_tag = self.version_tag or "*.*"
+            cmd = "describe --dirty --tags --long --match %s --first-parent" % version_tag
+
         cmd = cmd.split(" ")
         text = self.get_output(*cmd)
         version = self.parsed_version(text, dirty)

--- a/setupmeta/versioning.py
+++ b/setupmeta/versioning.py
@@ -185,6 +185,7 @@ class Strategy:
     def __init__(self, main, extra, branches, hook, **kwargs):
         self.main = main
         self.extra = extra
+        self.version_tag = kwargs.pop("version_tag", "*.*")
         if kwargs:
             setupmeta.warn("Ignored fields for 'versioning': %s" % kwargs)
 

--- a/tests/scenarios.py
+++ b/tests/scenarios.py
@@ -112,7 +112,8 @@ class Scenario:
         self.target = os.path.join(self.temp, "work")
 
         os.makedirs(self.origin)
-        self.run_git("init", "--bare", self.origin, cwd=self.temp)
+        # TODO: need to stop defaulting to 'master' branch, and use non-hardcoded git default instead ('main' nowadays)
+        self.run_git("init", "--bare", self.origin, "--initial-branch=master", cwd=self.temp)
         self.run_git("clone", self.origin, self.target, cwd=self.temp)
         copytree(self.folder, self.target)
 

--- a/tests/scenarios/bogus/expected.txt
+++ b/tests/scenarios/bogus/expected.txt
@@ -35,8 +35,6 @@ setup(
 
 :: check
 WARNING: patch version component should be .0 for versioning strategy...
-warning: CheckCommand: missing required meta-data: url
-warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied
 
 :: entrypoints
 WARNING: patch version component should be .0 for versioning strategy...

--- a/tests/scenarios/complex-reqs/expected.txt
+++ b/tests/scenarios/complex-reqs/expected.txt
@@ -40,8 +40,6 @@ setup(
 
 :: check
 [setupmeta] install_requires: 0 abstracted, 1 ignored, 0 untouched
-warning: CheckCommand: missing required meta-data: version, url
-warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied
 
 :: entrypoints
 

--- a/tests/scenarios/disabled/expected.txt
+++ b/tests/scenarios/disabled/expected.txt
@@ -8,8 +8,7 @@
 
 
 :: check
-warning: CheckCommand: missing required meta-data: version, url
-warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied
+
 
 :: entrypoints
 

--- a/tests/scenarios/pinned/expected.txt
+++ b/tests/scenarios/pinned/expected.txt
@@ -34,7 +34,7 @@ setup(
 )
 
 :: check
-warning: CheckCommand: missing required meta-data: url
+
 
 :: entrypoints
 

--- a/tests/scenarios/readmes/expected.txt
+++ b/tests/scenarios/readmes/expected.txt
@@ -30,8 +30,7 @@ setup(
 )
 
 :: check
-warning: CheckCommand: missing required meta-data: version, url
-warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied
+
 
 :: entrypoints
 

--- a/tests/scenarios/simple-src/expected.txt
+++ b/tests/scenarios/simple-src/expected.txt
@@ -27,8 +27,7 @@ setup(
 )
 
 :: check
-warning: CheckCommand: missing required meta-data: version, url
-warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied
+
 
 :: entrypoints
 

--- a/tests/scenarios/via_req_files/expected.txt
+++ b/tests/scenarios/via_req_files/expected.txt
@@ -37,8 +37,7 @@ setup(
 )
 
 :: check
-warning: CheckCommand: missing required meta-data: version, url
-warning: CheckCommand: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) should be supplied
+
 
 :: entrypoints
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -18,7 +18,7 @@ def scenario_folder(request):
         yield request.param
 
 
-@pytest.mark.skipif(sys.version_info.major < 3, reason="Sunsetting py2, minor diffs in warnings coming from old setuptools checks")
+@pytest.mark.skipif(sys.version_info < (3, 7), reason="EOL-ed versions have minor diffs in warnings coming from old setuptools checks")
 def test_scenario(scenario_folder):
     """Check that 'scenario' yields expected explain output"""
     py = ".".join(str(s) for s in sys.version_info[:2])

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -326,6 +326,15 @@ def test_malformed():
         assert "WARNING: 'name' not specified in setup.py" in logged
 
 
+def test_custom_version_tag():
+    with conftest.capture_output():
+        meta = new_meta(dict(main="distance", extra="", version_tag="v*.*"), scm=conftest.MockGit())
+        versioning = meta.versioning
+        assert versioning.strategy.version_tag == "v*.*"
+        assert versioning.scm.version_tag == "v*.*"
+        assert str(versioning.scm.get_version()) == "v0.1.2-3-g123"
+
+
 def test_distance_marker():
     with conftest.capture_output():
         meta = new_meta("{major}.{minor}.{distance}", scm=conftest.MockGit())

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py{27,36,37,38,39,310}, coverage, docs, style, security
+envlist = py{27,36,37,38,39,310,311}, coverage, docs, style, security
 skip_missing_interpreters = true
 
 
 [testenv]
-passenv = CI GITHUB_*
+passenv = CI
+          GITHUB_*
 setenv = COVERAGE_FILE={toxworkdir}/.coverage.{envname}
 usedevelop = True
 deps = -rtests/requirements.txt


### PR DESCRIPTION
This allows to configure git version tag without having to define complex env var `SETUPMETA_GIT_DESCRIBE_COMMAND`