### PR TITLE
Look for 'v*.*' git tags first, ignore non-conforming version tags

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,15 @@
 Release notes
 =============
 
+3.5.0 (2023-04-13)
+------------------
+
+* Look for ``v*.*`` git tags first, then ``*.*``
+
+* Ignore git tags that do not pass regex ``^v?[0-9]+\.[0-9]+``,
+  default to ``0.0.0`` in that case, and issue a WARNING
+
+
 3.4.0 (2023-01-25)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,11 @@ See examples_ for more.
 
 **Note**: ``setupmeta``'s versioning is based on::
 
-    git describe --dirty --tags --long --match *.* --first-parent
+    git describe --dirty --tags --long --first-parent --match 'v*.*'
+
+    # Then, if above yields nothing, we try the more vague '*.*'
+
+    git describe --dirty --tags --long --first-parent --match '*.*'
 
 you will need **git version >= 1.8.4** if you wish to use ``setupmeta``'s versioning capabilities.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -285,23 +285,18 @@ def run_internal_setup_py(folder, *args):
 
 
 class MockGit(Git):
-    def __init__(
-        self,
-        dirty=True,
-        describe="v0.1.2-3-g123",
-        branch="master",
-        commitid="abc123",
-        local_tags="",
-        remote_tags="",
-    ):
-        self.dirty = dirty
+    def __init__(self, describe="v0.1.2-3-g123-dirty", branch="master", commitid="abc123", local_tags="", remote_tags=""):
         self.describe = describe
         self.branch = branch
         self.commitid = commitid
-        self.status_message = "## master...origin/master"
+        self.status_message = "## %s...origin/%s" % (branch, branch)
         self._local_tags = local_tags
         self._remote_tags = remote_tags
         Git.__init__(self, TESTS)
+
+    @property
+    def dirty(self):
+        return "-dirty" in self.describe
 
     def get_output(self, cmd, *args, **kwargs):
         if cmd.startswith("diff"):


### PR DESCRIPTION
When no explicit `version_tag` was configured (vast majority of cases), look for `v*.*` git tags first, and if that doesn't yield anything, look for the more vague `*.*`

Ignore any tag that doesn't have at least a leading `[0-9]\.[0-9]`, default to `0.0.0` for such tags and issue a WARNING