### PR TITLE
Extract Requires-Dist from PKG-INFO when present

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,7 +2,13 @@
 Release notes
 =============
 
-3.5.0 (2023-09-20)
+3.5.0 (2023-09-22)
+------------------
+
+* Better support for PEP-517, extract ``Requires-Dist:`` from ``PKG-INFO`` if ``requires.txt`` is missing
+
+
+3.4.1 (2023-09-22)
 ------------------
 
 * Removed support for py2

--- a/setupmeta/__init__.py
+++ b/setupmeta/__init__.py
@@ -691,6 +691,20 @@ class RequirementsFile:
             req.finalize()
             return req
 
+    @classmethod
+    def from_lines(cls, lines, do_abstract=False, source_path=None):
+        """
+        :param list[str] lines: Requirement lines, as found in METADATA 'Requires-Dist:' for example
+        :param bool do_abstract: If True, automatically abstract reqs of the form <name>==<version>
+        :param str source_path: Reference to file where 'lines' came from
+        :return RequirementsFile|None: Associated object, if possible
+        """
+        req = cls(do_abstract=do_abstract)
+        req.scan(lines, source_path=source_path)
+        if req.reqs is not None:
+            req.finalize()
+            return req
+
 
 def find_requirements(*relative_paths):
     """ Read old-school requirements.txt type file """
@@ -712,9 +726,10 @@ class Requirements:
         """
         :param setupmeta.model.PackageInfo pkg_info: PKG-INFO, when available
         """
-        if pkg_info and pkg_info.requires_txt:
-            self.install_requires = RequirementsFile.from_file(pkg_info.requires_txt, do_abstract=False)
-            return
+        if pkg_info:
+            self.install_requires = pkg_info.get_requirements()
+            if self.install_requires:
+                return
 
         self.install_requires = find_requirements(
             "requirements.in",  # .in files are preferred when present

--- a/tests/scenarios/packaged/PKG-INFO
+++ b/tests/scenarios/packaged/PKG-INFO
@@ -7,6 +7,9 @@ Author: Someone
 Author-email: someone@example.com
 License: MIT
 Download-URL: http://example.com/pre-packaged/releases/download/v1.7.1/pickley
+Requires-Dist: setuptools>=46.1
+Requires-Dist: pytest-cov
+Requires-Dist: flake8
 Description:
         # Project description
 

--- a/tests/scenarios/packaged/expected.txt
+++ b/tests/scenarios/packaged/expected.txt
@@ -5,7 +5,7 @@
                   description: (PKG-INFO                                ) Project description
                  download_url: (PKG-INFO                                ) http://example.com/pre-packaged/releases/download/v1.7.1/pickley
                  entry_points: (src/pre_packaged.egg-info/entry_points.txt) [console_scripts] pre-packaged-test = pre_packaged:main
-             install_requires: (src/pre_packaged.egg-info/requires.txt  ) ["setuptools>=46.1", "pytest-cov", "flake8"]
+             install_requires: (PKG-INFO/Requires-Dist                  ) ["setuptools>=46.1", "pytest-cov", "flake8"]
                       license: (PKG-INFO                                ) MIT
              long_description: (PKG-INFO                                ) # Project description This scenario simulates a PKG, with no git source available. During testing, `src...
                            \_: (README.md                               ) # Project description This scenario simulates a PKG, with no git source available. During testing, `src...
@@ -22,9 +22,9 @@ long_description_content_type: (PKG-INFO                                ) text/m
 :: explain -d
     # This reflects only auto-fill, doesn't look at explicit settings from your setup.py
     install_requires=[
-        "setuptools>=46.1",  # from src/pre_packaged.egg-info/requires.txt:1
-        "pytest-cov",        # from src/pre_packaged.egg-info/requires.txt:2
-        "flake8",            # from src/pre_packaged.egg-info/requires.txt:3
+        "setuptools>=46.1",  # from PKG-INFO/Requires-Dist:1
+        "pytest-cov",        # from PKG-INFO/Requires-Dist:2
+        "flake8",            # from PKG-INFO/Requires-Dist:3
     ],
 
 :: explain --expand
@@ -41,7 +41,7 @@ setup(
     download_url="http://example.com/pre-packaged/releases/download/v1.7.1/pickley", # from PKG-INFO
     entry_points="""[console_scripts]
 pre-packaged-test = pre_packaged:main""",                            # from src/pre_packaged.egg-info/entry_points.txt
-    install_requires=["setuptools>=46.1", "pytest-cov", "flake8"],   # from src/pre_packaged.egg-info/requires.txt
+    install_requires=["setuptools>=46.1", "pytest-cov", "flake8"],   # from PKG-INFO/Requires-Dist
     license="MIT",                                                   # from PKG-INFO
     long_description=open("PKG-INFO").read(),                        # from PKG-INFO
     long_description_content_type="text/markdown",                   # from PKG-INFO


### PR DESCRIPTION
setuptools 68.2+ stopped producing a `requires.txt`