### PR TITLE
Bypass pre-commit hooks when committing version bump

### DIFF
--- a/setupmeta/scm.py
+++ b/setupmeta/scm.py
@@ -235,7 +235,7 @@ class Git(Scm):
 
         relative_paths = sorted(set(relative_paths))
         self.run(commit, "add", *relative_paths)
-        self.run(commit, "commit", "-m", "Version %s" % next_version)
+        self.run(commit, "commit", "-m", "Version %s" % next_version, "--no-verify")
         if push:
             if self.has_origin():
                 self.run(commit, "push", "origin")


### PR DESCRIPTION
I often use the `no-commit-to-branch` pre-commit hook (https://github.com/pre-commit/pre-commit-hooks#no-commit-to-branch) to prevent accidental commits to my main branch
locally. Unfortunately, this pre-commit hook prevents bumping with the commit flag from working successfully.

The change in this PR completely bypasses pre-commit hooks when bumping the version, which I believe should always be safe to do so.