### PR TITLE
Drop PEP440 dependency

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pep440
+packaging
 pytest-cov
 setuptools  # Needed by definition, as setupmeta is setuptools hook

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -41,7 +41,7 @@ def test_check_dependencies():
         run_setup_py(
             ["check", "--deptree"],
             """
-                pep440==.+
+                packaging==.+
                 pytest-cov==.+
             """,
             folder=conftest.PROJECT_DIR,

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -2,7 +2,7 @@ import os
 import sys
 from unittest.mock import patch
 
-import pep440
+from packaging.version import parse
 import pytest
 
 import setupmeta
@@ -161,7 +161,7 @@ def quick_check(versioning, expected, describe="v0.1.2-5-g123-dirty", compliant=
     assert meta.version == expected
     if compliant:
         main_part, _, _ = meta.version.partition("+")
-        assert pep440.is_canonical(main_part)
+        assert str(parse(main_part)) == main_part
 
     versioning = meta.versioning
     assert versioning.enabled


### PR DESCRIPTION
Just a random drive-by PR. Noticed from `python-pep440` being orphaned on Fedora that there are some packages that still require it, this being one of them. In principle `packaging` should be used instead of all of these kind of projects moving forward.

I am not sure what the state of this project is (in light of PEP517 and PEP621), but I make this PR to be able to remove the dependency in `python-setupmeta`.