### PR TITLE
Drop PEP440 dependency

### DIFF
--- a/examples/single/expected.txt
+++ b/examples/single/expected.txt
@@ -10,7 +10,7 @@
 long_description_content_type: (README.rst  ) text/x-rst
                          name: (explicit    ) single
                    py_modules: (auto-fill   ) ["single"]
-               setup_requires: (explicit    ) ["setupmeta", "setuptools_scm"]
+               setup_requires: (explicit    ) ["setupmeta"]
                           url: (missing     ) - Consider specifying 'url'
                       version: (single.py:8 ) 0.1.0
 
@@ -33,7 +33,6 @@ setup(
     long_description_content_type="text/x-rst", # from README.rst
     name="single",
     py_modules=["single"],
-    setup_requires=["setuptools_scm"],
     version=__version__,                    # from single.py:8
 )
 

--- a/examples/single/setup.py
+++ b/examples/single/setup.py
@@ -8,5 +8,5 @@ from setuptools import setup
 
 setup(
     name="single",
-    setup_requires=["setupmeta", "setuptools_scm"],
+    setup_requires=["setupmeta"],
 )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-pep440
+packaging
 pytest-cov
 setuptools  # Needed by definition, as setupmeta is setuptools hook

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -41,7 +41,7 @@ def test_check_dependencies():
         run_setup_py(
             ["check", "--deptree"],
             """
-                pep440==.+
+                packaging==.+
                 pytest-cov==.+
             """,
             folder=conftest.PROJECT_DIR,

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -40,8 +40,8 @@ def test_check_dependencies():
         # check --deptree is only useful when ran from a venv, which is guaranteed when invoking tests via tox (but may not be otherwise)
         run_setup_py(
             ["check", "--deptree"],
-            """
-                packaging==.+
+            r"""
+                packaging \[required: Any, installed: [\d+.]+\]
                 pytest-cov==.+
             """,
             folder=conftest.PROJECT_DIR,

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -78,9 +78,9 @@ def test_run_program():
         assert setupmeta.run_program("ls", capture=True, dryrun=True) is None
         assert setupmeta.run_program("ls", capture=False, dryrun=True) == 0
         assert setupmeta.run_program("ls", "foo/does/not/exist", capture=None) != 0
-        assert setupmeta.run_program("pip", "--version", capture=True)
-        assert setupmeta.run_program("pip", "foo bar", capture=True) == ""
-        assert "unknown command" in setupmeta.run_program("pip", "foo bar", capture="all")
+        assert setupmeta.run_program("python", "--version", capture=True)
+        assert setupmeta.run_program("python", "-c", "foo", capture=True) == ""
+        assert "NameError:" in setupmeta.run_program("python", "-c", "foo", capture="all")
         assert setupmeta.run_program("/foo/does/not/exist", capture=True, dryrun=True) is None
         assert setupmeta.run_program("/foo/does/not/exist", capture=False) != 0
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -2,7 +2,7 @@ import os
 import sys
 from unittest.mock import patch
 
-import pep440
+from packaging.version import parse
 import pytest
 
 import setupmeta
@@ -161,7 +161,7 @@ def quick_check(versioning, expected, describe="v0.1.2-5-g123-dirty", compliant=
     assert meta.version == expected
     if compliant:
         main_part, _, _ = meta.version.partition("+")
-        assert pep440.is_canonical(main_part)
+        assert str(parse(main_part)) == main_part
 
     versioning = meta.versioning
     assert versioning.enabled


### PR DESCRIPTION
Thanks to @LecrisUT for contrib: https://github.com/codrsquad/setupmeta/pull/86

Just a random drive-by PR. Noticed from python-pep440 being orphaned on Fedora that there are some packages that still require it, this being one of them. In principle packaging should be used instead of all of these kind of projects moving forward.

I am not sure what the state of this project is (in light of PEP517 and PEP621), but I make this PR to be able to remove the dependency in python-setupmeta.