### PR TITLE
Allow for interpreters not named "python" in test_run_program

### DIFF
--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 import pytest
 
@@ -78,9 +79,9 @@ def test_run_program():
         assert setupmeta.run_program("ls", capture=True, dryrun=True) is None
         assert setupmeta.run_program("ls", capture=False, dryrun=True) == 0
         assert setupmeta.run_program("ls", "foo/does/not/exist", capture=None) != 0
-        assert setupmeta.run_program("python", "--version", capture=True)
-        assert setupmeta.run_program("python", "-c", "foo", capture=True) == ""
-        assert "NameError:" in setupmeta.run_program("python", "-c", "foo", capture="all")
+        assert setupmeta.run_program(sys.executable, "--version", capture=True)
+        assert setupmeta.run_program(sys.executable, "-c", "foo", capture=True) == ""
+        assert "NameError:" in setupmeta.run_program(sys.executable, "-c", "foo", capture="all")
         assert setupmeta.run_program("/foo/does/not/exist", capture=True, dryrun=True) is None
         assert setupmeta.run_program("/foo/does/not/exist", capture=False) != 0
 


### PR DESCRIPTION
For example, in Fedora, the system Python is `python3` unless the `python-unversioned-command` package is installed.

Using `sys.executable` instead of `"python"` in `test_run_program` means we invoke the same Python interpreter that is running the tests, which is more reliable across various environments.